### PR TITLE
removes pull secret

### DIFF
--- a/helm/e2e-app-chart/templates/deployment.yaml
+++ b/helm/e2e-app-chart/templates/deployment.yaml
@@ -32,5 +32,3 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
-      imagePullSecrets:
-      - name: e2e-app-pull-secret

--- a/helm/e2e-app-chart/templates/pull-secret.yml
+++ b/helm/e2e-app-chart/templates/pull-secret.yml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/dockerconfigjson
-metadata:
-  name: e2e-app-pull-secret
-  namespace: e2e
-data:
-  .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2737. The e2e-app is public anyways and there is no cool mechanism now to easily setup pull secrets for charts we use within integration tests. 