### PR TITLE
removes namespace

### DIFF
--- a/helm/e2e-app-chart/templates/namespace.yaml
+++ b/helm/e2e-app-chart/templates/namespace.yaml
@@ -1,4 +1,0 @@
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: e2e-app


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2737. I found this: https://github.com/kubernetes/helm/issues/2853#issuecomment-325394823. So we should always use the namespaces we provide to the helm installation process. It is not necessary to include a separate namespace manifest in charts. This failed earlier because I worked with the default namespace for the installation but used the e2e namespace in the chart. This PR gets this straight. 