### PR TITLE
Add pod disruption budget

### DIFF
--- a/helm/e2e-app-chart/templates/deployment.yaml
+++ b/helm/e2e-app-chart/templates/deployment.yaml
@@ -9,7 +9,8 @@ spec:
   replicas: 2
   revisionHistoryLimit: 3
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/helm/e2e-app-chart/templates/pdb.yaml
+++ b/helm/e2e-app-chart/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: e2e-app
+  namespace: e2e-app
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: e2e-app


### PR DESCRIPTION
Add PDB to the e2e app chart templates. The goal is to not have false positives when we upgrade clusters.