### PR TITLE
run e2e app as non root to fix e2e tests in tenant clusters

### DIFF
--- a/helm/e2e-app-chart/templates/deployment.yaml
+++ b/helm/e2e-app-chart/templates/deployment.yaml
@@ -42,4 +42,7 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
       serviceAccountName: e2e-app

--- a/helm/e2e-app-chart/values.yaml
+++ b/helm/e2e-app-chart/values.yaml
@@ -1,0 +1,2 @@
+userID: 1000
+groupID: 1000


### PR DESCRIPTION
@tfussell  and I debug the e2e test in the `aws-operator` and found that the `e2e-app` does not come up properly. We just merge this and see if it improves the situation. 

```
xh3b4sd@ip-10-12-1-15 ~ $ sudo ./kubectl --kubeconfig /etc/kubernetes/kubeconfig/kubelet.yaml describe pod -n e2e-app e2e-app
...
Events:
  Type     Reason          Age               From                                                   Message
  ----     ------          ----              ----                                                   -------
  Normal   Scheduled       32s               default-scheduler                                      Successfully assigned e2e-app/e2e-app-85b4ffb475-c9lkz to ip-10-12-1-114.eu-central-1.compute.internal
  Normal   Pulling         31s               kubelet, ip-10-12-1-114.eu-central-1.compute.internal  Pulling image "quay.io/giantswarm/e2e-app:c8374757097fef2396f9df4a9599cf3df0e760db"
  Normal   Pulled          28s               kubelet, ip-10-12-1-114.eu-central-1.compute.internal  Successfully pulled image "quay.io/giantswarm/e2e-app:c8374757097fef2396f9df4a9599cf3df0e760db"
  Normal   SandboxChanged  27s               kubelet, ip-10-12-1-114.eu-central-1.compute.internal  Pod sandbox changed, it will be killed and re-created.
  Warning  Failed          1s (x6 over 28s)  kubelet, ip-10-12-1-114.eu-central-1.compute.internal  Error: container has runAsNonRoot and image will run as root
  Normal   Pulled          1s (x5 over 26s)  kubelet, ip-10-12-1-114.eu-central-1.compute.internal  Container image "quay.io/giantswarm/e2e-app:c8374757097fef2396f9df4a9599cf3df0e760db" already present on machine
```

We got basically inspired by https://github.com/giantswarm/node-operator/pull/89. 