### PR TITLE
Use apps v1 API

### DIFF
--- a/helm/e2e-app-chart/templates/deployment.yaml
+++ b/helm/e2e-app-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: e2e-app


### PR DESCRIPTION
Apps v1 API is GA since k8s 1.9, released in December 2017 (see [here](https://kubernetes.io/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/)).
k8s 1.16 drops a lot of previously deprecated APIs, including extensions/v1beta1 (see [here](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals)).
Oldest k8s we still support is 1.13 so this update should be safe and help with 1.16 support in the near future.