### PR TITLE
Hardcode security context user:group

### DIFF
--- a/helm/e2e-app-chart/templates/deployment.yaml
+++ b/helm/e2e-app-chart/templates/deployment.yaml
@@ -46,6 +46,6 @@ spec:
             cpu: 100m
             memory: 100Mi
       securityContext:
-        runAsUser: {{ .Values.userID }}
-        runAsGroup: {{ .Values.groupID }}
+        runAsUser: 1000
+        runAsGroup: 1000
       serviceAccountName: e2e-app

--- a/helm/e2e-app-chart/values.yaml
+++ b/helm/e2e-app-chart/values.yaml
@@ -1,2 +1,0 @@
-userID: 1000
-groupID: 1000


### PR DESCRIPTION
aws-operator draining e2e tests are failing for https://github.com/giantswarm/aws-operator/pull/1964
e2e-app is failing to start, it's unexpectedly trying to start as root and kubelet is preventing that due to PSP which is in place.

After debugging it looks like that the user and group configuration values are not being applied in the Deployment template of e2e-app-chart.

This PR is an attempt to eliminate this by hardcoding the user and group in the template.

Followup TODO is to add e2e basic if not also security related tests for e2e-app-chart in e2e-app repo, and optionally make these values configurable again.